### PR TITLE
split out platformOS apis, generate openapiv3 via gnostic

### DIFF
--- a/dme/Makefile
+++ b/dme/Makefile
@@ -2,18 +2,33 @@
 
 GOOGLEAPIS	= ../third_party/googleapis
 INCLUDE		= -I. -I${GOOGLEAPIS} -I../edgeprotogen
-BUILTIN		= Mgoogle/api/annotations.proto=${GOOGLEAPIS}/google/api,Mgoogle/protobuf/descriptor.proto=${GOOGLEAPIS}/google/protobuf,Medgeprotogen.proto=.,Mloc.proto=.,Mappcommon.proto=.
+BUILTIN		= Mgoogle/api/annotations.proto=${GOOGLEAPIS}/google/api,Mgoogle/protobuf/descriptor.proto=${GOOGLEAPIS}/google/protobuf,Medgeprotogen.proto=.,Mloc.proto=.,Mappcommon.proto=.,Mapp-client.proto=.
+LASTTAG		= $(shell git describe --tags --abbrev=0)
 
 # go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@latest
 # https://npmjs.com/package/swagger2openapi
-define gendoc
+define gendoc-swagger
 	protoc ${INCLUDE} --openapiv2_out=${BUILTIN},M$(1)=.,logtostderr=true,allow_merge=true,merge_file_name=$(basename $(1)):. $(1)
 	swagger2openapi -o $(basename $(1)).yaml -y $(basename $(1)).swagger.json
 endef
 
+# Generate doc via swagger generation, then converting swagger to openapiv3
+doc-swagger:
+	$(call gendoc-swagger,app-client.proto)
+	$(call gendoc-swagger,app-client-platos.proto)
+	$(call gendoc-swagger,locverify.proto)
+	$(call gendoc-swagger,qos.proto)
+	$(call gendoc-swagger,qos-position.proto)
+	$(call gendoc-swagger,session.proto)
+
+
+# go install github.com/google/gnostic/cmd/protoc-gen-openapi@latest
+define gendoc
+	protoc ${INCLUDE} --openapi_out=${BUILTIN},M$(1)=.,naming=proto,enum_type=string,version=$(LASTTAG):. $(1)
+	mv openapi.yaml $(basename $(1)).yaml
+endef
+
+# Generate doc directly from proto to openapiv3
 doc:
 	$(call gendoc,app-client.proto)
-	$(call gendoc,locverify.proto)
-	$(call gendoc,qos.proto)
-	$(call gendoc,qos-position.proto)
 	$(call gendoc,session.proto)

--- a/dme/app-client-platos.proto
+++ b/dme/app-client-platos.proto
@@ -1,0 +1,125 @@
+// Copyright 2022 MobiledgeX, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Device service APIs
+
+syntax = "proto3";
+package distributed_match_engine;
+
+import "google/api/annotations.proto";
+import "app-client.proto";
+//import "appcommon.proto";
+
+message PlatformFindCloudletRequest {
+  /*
+   * API version
+   *
+   * _(hidden)_ Reserved for future use
+   */
+  uint32 ver = 1;
+  /*
+   * Session Cookie
+   *
+   * Session Cookie from RegisterClientRequest
+   */
+  string session_cookie = 2;
+  /*
+   * Carrier Name
+   *
+   * _(optional)_ By default, all SDKs will automatically fill in this parameter with the MCC+MNC of your current provider. Only override this parameter if you need to filter for a specific carrier on the DME. The DME will filter for App instances that are associated with the specified carrier.
+   * If you wish to search for any app instance on the DME regardless of carrier name, you can input “” to consider all carriers as “Any”.
+   */
+  string carrier_name = 3;
+  /*
+   * Client Token
+   *
+   * Token with encoded client data
+   */
+  string client_token = 4;
+  /*
+   * Tags
+   *
+   * _(optional)_ Vendor specific data
+   */
+  map<string, string> tags = 100;
+}
+
+message FqdnListRequest {
+  /*
+   * API version
+   *
+   * _(hidden)_ Reserved for future use
+   */
+  uint32 ver = 1;
+  // Session Cookie from RegisterClientRequest
+  string session_cookie = 2;
+  // _(removed)_ Cell id where the client is
+  reserved "cell_id";
+  reserved 3;
+  // _(optional)_ Vendor specific data
+  map<string, string> tags = 100;
+}
+
+message AppFqdn{
+  // App  Name
+  string app_name = 1;
+  // App Version
+  string app_vers = 2;
+  // App organization name
+  string org_name = 3;
+  // App FQDN
+  repeated string fqdns = 4;
+  // _(optional)_ Android package name
+  string android_package_name = 5;
+}
+
+message FqdnListReply{
+  /*
+   * API version
+   *
+   * _(hidden)_ Reserved for future use
+   */
+  uint32 ver = 1;
+  // Status of the reply
+  enum FLStatus {
+    FL_UNDEFINED = 0;
+    FL_SUCCESS = 1;
+    FL_FAIL = 2;
+  }
+  repeated AppFqdn app_fqdns = 3;
+  FLStatus status = 4;
+  // _(optional)_ Vendor specific data
+  map<string, string> tags = 100;
+}
+
+service PlatformOS {
+  /*
+   * PlatformFindCloudlet
+   *
+   * Similar to FindCloudlet, except uses a token for client data.
+   * This API is only applicable for Platform Applications.
+   */
+  rpc PlatformFindCloudlet(PlatformFindCloudletRequest) returns (FindCloudletReply) {
+    option (google.api.http) = {
+      post: "/v1/platformfindcloudlet"
+      body: "*"
+    };
+  }
+  rpc GetFqdnList(FqdnListRequest) returns (FqdnListReply) {
+    option (google.api.http) = {
+      post: "/v1/getfqdnlist"
+      body: "*"
+    };
+  }
+}

--- a/dme/app-client-platos.proto
+++ b/dme/app-client-platos.proto
@@ -19,7 +19,6 @@ package distributed_match_engine;
 
 import "google/api/annotations.proto";
 import "app-client.proto";
-//import "appcommon.proto";
 
 message PlatformFindCloudletRequest {
   /*

--- a/dme/app-client.proto
+++ b/dme/app-client.proto
@@ -69,40 +69,6 @@ message FindCloudletRequest {
   map<string, string> tags = 100;
 }
 
-message PlatformFindCloudletRequest {
-  /*
-   * API version
-   *
-   * _(hidden)_ Reserved for future use
-   */
-  uint32 ver = 1;
-  /*
-   * Session Cookie
-   *
-   * Session Cookie from RegisterClientRequest
-   */
-  string session_cookie = 2;
-  /*
-   * Carrier Name
-   *
-   * _(optional)_ By default, all SDKs will automatically fill in this parameter with the MCC+MNC of your current provider. Only override this parameter if you need to filter for a specific carrier on the DME. The DME will filter for App instances that are associated with the specified carrier.
-   * If you wish to search for any app instance on the DME regardless of carrier name, you can input “” to consider all carriers as “Any”.
-   */
-  string carrier_name = 3;
-  /*
-   * Client Token
-   *
-   * Token with encoded client data
-   */
-  string client_token = 4;
-  /*
-   * Tags
-   *
-   * _(optional)_ Vendor specific data
-   */
-  map<string, string> tags = 100;
-}
-
 message FindCloudletReply {
   /*
    * API version
@@ -209,54 +175,6 @@ message AppInstListReply {
   }
   AIStatus status = 2;
   repeated CloudletLocation cloudlets = 3;
-  // _(optional)_ Vendor specific data
-  map<string, string> tags = 100;
-}
-
-message FqdnListRequest {
-  /*
-   * API version
-   *
-   * _(hidden)_ Reserved for future use
-   */
-  uint32 ver = 1;
-  // Session Cookie from RegisterClientRequest
-  string session_cookie = 2;
-  // _(removed)_ Cell id where the client is
-  reserved "cell_id";
-  reserved 3;
-  // _(optional)_ Vendor specific data
-  map<string, string> tags = 100;
-}
-
-message AppFqdn{
-  // App  Name
-  string app_name = 1;
-  // App Version
-  string app_vers = 2;
-  // App organization name
-  string org_name = 3;
-  // App FQDN
-  repeated string fqdns = 4;
-  // _(optional)_ Android package name
-  string android_package_name = 5;
-}
-
-message FqdnListReply{
-  /*
-   * API version
-   *
-   * _(hidden)_ Reserved for future use
-   */
-  uint32 ver = 1;
-  // Status of the reply
-  enum FLStatus {
-    FL_UNDEFINED = 0;
-    FL_SUCCESS = 1;
-    FL_FAIL = 2;
-  }
-  repeated AppFqdn app_fqdns = 3;
-  FLStatus status = 4;
   // _(optional)_ Vendor specific data
   map<string, string> tags = 100;
 }
@@ -373,15 +291,15 @@ message ServerEdgeEvent {
   map<string, string> tags = 100;
 }
 
+/*
+ * APIs for application clients on devices to interact with Edge Cloud application services.
+ */
 service MatchEngineApi {
   /*
    * FindCloudlet
    *
-   * Locates the most optimal edge computing footprint and allows the
-   * registered application to find the application backend by leveraging the
-   * location, application subscription, and service provider agreement. If
-   * there are no suitable cloudlet instances available, the client may connect
-   * to the application server located in the public cloud.
+   * Find the best application service running on a cloudlet in the
+   * Edge Cloud for the client to use, based on proximity and other policies.
    */
    rpc FindCloudlet(FindCloudletRequest) returns (FindCloudletReply) {
     option (google.api.http) = {
@@ -390,35 +308,38 @@ service MatchEngineApi {
     };
   }
   /*
-   * PlatformFindCloudlet
+   * GetAppInstList
    *
-   * Similar to FindCloudlet, except uses a token for client data.
-   * This API is only applicable for Platform Applications.
+   * Like FindCloudlet, but returns a short list of the best instances
+   * instead of a single result, allowing the client to choose based on
+   * its own criteria, or maintain several parallel connections to
+   * different sites.
    */
-  rpc PlatformFindCloudlet(PlatformFindCloudletRequest) returns (FindCloudletReply) {
-    option (google.api.http) = {
-      post: "/v1/platformfindcloudlet"
-      body: "*"
-    };
-  }
   rpc GetAppInstList(AppInstListRequest) returns (AppInstListReply) {
     option (google.api.http) = {
       post: "/v1/getappinstlist"
       body: "*"
     };
   }
-  rpc GetFqdnList(FqdnListRequest) returns (FqdnListReply) {
-    option (google.api.http) = {
-      post: "/v1/getfqdnlist"
-      body: "*"
-    };
-  }
+  /*
+   * GetAppOfficialFqdn
+   *
+   * Get an App's official FQDN if configured, which points to a default
+   * public cloud instance of the application service that can be
+   * used if no Edge Cloud application instances are available.
+   */
   rpc GetAppOfficialFqdn(AppOfficialFqdnRequest) returns (AppOfficialFqdnReply) {
     option (google.api.http) = {
       post: "/v1/getappofficialfqdn"
       body: "*"
     };
   }
+  /*
+   * StreamEdgeEvent
+   *
+   * Streams events bidirectionally between device client and the
+   * Edge Cloud platform for notifications.
+   */
   rpc StreamEdgeEvent(stream ClientEdgeEvent) returns (stream ServerEdgeEvent) {
     option (google.api.http) = {
       post: "/v1/streamedgeevent"

--- a/dme/appcommon.proto
+++ b/dme/appcommon.proto
@@ -38,7 +38,7 @@ enum LProto {
 
 // Application Port
 //
-// AppPort describes an L4 or L7 public access port/path mapping. This is used to track external to internal mappings for access via a shared load balancer or reverse proxy.
+// AppPort describes an L4 public access port/path mapping. This is used to track external to internal mappings for access via a shared load balancer or reverse proxy.
 message AppPort {
   // TCP (L4) or UDP (L4) protocol
   LProto proto = 1;
@@ -46,7 +46,8 @@ message AppPort {
   int32 internal_port = 2;
   // Public facing port for TCP/UDP (may be mapped on shared LB reverse proxy)
   int32 public_port = 3;
-  // skip 4 to preserve the numbering. 4 was path_prefix but was removed since we dont need it after removed http
+  // path_prefix was removed since we dont need it after removed http
+  reserved 4;
   // FQDN prefix to append to base FQDN in FindCloudlet response. May be empty.
   string fqdn_prefix = 5;
   // A non-zero end port indicates a port range from internal port to end port, inclusive.


### PR DESCRIPTION
Changes:
- Split out platformOS-specific APIs from app-client.proto into app-client-platos.proto. These APIs are somewhat deprecated since that platformOS initiative fizzled, so move them out so they don't complicate and confuse the app-client apis.
- Change the openapiv3 generation from a proto -> swaggerv2 -> openapiv3, to a direct conversion of proto -> openapiv3, which yields a cleaner doc.
- Cleaned up some of the comments for documentation
