### PR TITLE
add generated openapi docs

### DIFF
--- a/dme/Makefile
+++ b/dme/Makefile
@@ -31,4 +31,7 @@ endef
 # Generate doc directly from proto to openapiv3
 doc:
 	$(call gendoc,app-client.proto)
+	$(call gendoc,locverify.proto)
+	$(call gendoc,qos.proto)
+	$(call gendoc,qos-position.proto)
 	$(call gendoc,session.proto)

--- a/dme/app-client.yaml
+++ b/dme/app-client.yaml
@@ -1,0 +1,617 @@
+# Generated with protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: MatchEngineApi API
+    description: APIs for application clients on devices to interact with Edge Cloud application services.
+    version: v1.2.4.1-hf8
+paths:
+    /v1/findcloudlet:
+        post:
+            tags:
+                - MatchEngineApi
+            description: |-
+                FindCloudlet
+
+                 Find the best application service running on a cloudlet in the
+                 Edge Cloud for the client to use, based on proximity and other policies.
+            operationId: MatchEngineApi_FindCloudlet
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/FindCloudletRequest'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/FindCloudletReply'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/getappinstlist:
+        post:
+            tags:
+                - MatchEngineApi
+            description: |-
+                GetAppInstList
+
+                 Like FindCloudlet, but returns a short list of the best instances
+                 instead of a single result, allowing the client to choose based on
+                 its own criteria, or maintain several parallel connections to
+                 different sites.
+            operationId: MatchEngineApi_GetAppInstList
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/AppInstListRequest'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AppInstListReply'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/getappofficialfqdn:
+        post:
+            tags:
+                - MatchEngineApi
+            description: |-
+                GetAppOfficialFqdn
+
+                 Get an App's official FQDN if configured, which points to a default
+                 public cloud instance of the application service that can be
+                 used if no Edge Cloud application instances are available.
+            operationId: MatchEngineApi_GetAppOfficialFqdn
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/AppOfficialFqdnRequest'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AppOfficialFqdnReply'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/streamedgeevent:
+        post:
+            tags:
+                - MatchEngineApi
+            description: |-
+                StreamEdgeEvent
+
+                 Streams events bidirectionally between device client and the
+                 Edge Cloud platform for notifications.
+            operationId: MatchEngineApi_StreamEdgeEvent
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ClientEdgeEvent'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ServerEdgeEvent'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+components:
+    schemas:
+        AppInstListReply:
+            type: object
+            properties:
+                ver:
+                    type: integer
+                    description: API version _(hidden)_ Reserved for future use
+                    format: uint32
+                status:
+                    enum:
+                        - AI_UNDEFINED
+                        - AI_SUCCESS
+                        - AI_FAIL
+                    type: string
+                    format: enum
+                cloudlets:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/CloudletLocation'
+                tags:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: _(optional)_ Vendor specific data
+        AppInstListRequest:
+            type: object
+            properties:
+                ver:
+                    type: integer
+                    description: API version _(hidden)_ Reserved for future use
+                    format: uint32
+                session_cookie:
+                    type: string
+                    description: Session Cookie from RegisterClientRequest
+                carrier_name:
+                    type: string
+                    description: Carrier Name _(optional)_ By default, all SDKs will automatically fill in this parameter with the MCC+MNC of your current provider. Only override this parameter if you need to filter for a specific carrier on the DME. The DME will filter for App instances that are associated with the specified carrier. If you wish to search for any App Instance on the DME regardless of carrier name, you can input “” to consider all carriers as “Any”.
+                gps_location:
+                    $ref: '#/components/schemas/Loc'
+                limit:
+                    type: integer
+                    description: _(optional)_ Limit the number of results, defaults to 3
+                    format: uint32
+                tags:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: _(optional)_ Vendor specific data
+        AppOfficialFqdnReply:
+            type: object
+            properties:
+                ver:
+                    type: integer
+                    description: API version _(hidden)_ Reserved for future use
+                    format: uint32
+                app_official_fqdn:
+                    type: string
+                    description: The FQDN to which the app is reached independent of the edge
+                client_token:
+                    type: string
+                    description: Tokenized client data
+                status:
+                    enum:
+                        - AOF_UNDEFINED
+                        - AOF_SUCCESS
+                        - AOF_FAIL
+                    type: string
+                    description: Status of the reply
+                    format: enum
+                ports:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AppPort'
+                    description: List of Service Endpoints for AppInst
+                tags:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: _(optional)_ Vendor specific data
+        AppOfficialFqdnRequest:
+            type: object
+            properties:
+                ver:
+                    type: integer
+                    description: API version _(hidden)_ Reserved for future use
+                    format: uint32
+                session_cookie:
+                    type: string
+                    description: Session Cookie from RegisterClientRequest
+                gps_location:
+                    $ref: '#/components/schemas/Loc'
+                tags:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: _(optional)_ Vendor specific data
+        AppPort:
+            type: object
+            properties:
+                proto:
+                    enum:
+                        - L_PROTO_UNKNOWN
+                        - L_PROTO_TCP
+                        - L_PROTO_UDP
+                    type: string
+                    description: TCP (L4) or UDP (L4) protocol
+                    format: enum
+                internal_port:
+                    type: integer
+                    description: Container port
+                    format: int32
+                public_port:
+                    type: integer
+                    description: Public facing port for TCP/UDP (may be mapped on shared LB reverse proxy)
+                    format: int32
+                fqdn_prefix:
+                    type: string
+                    description: FQDN prefix to append to base FQDN in FindCloudlet response. May be empty.
+                end_port:
+                    type: integer
+                    description: A non-zero end port indicates a port range from internal port to end port, inclusive.
+                    format: int32
+                tls:
+                    type: boolean
+                    description: TLS termination for this port
+                nginx:
+                    type: boolean
+                    description: Use nginx proxy for this port if you really need a transparent proxy (udp only)
+                max_pkt_size:
+                    type: integer
+                    description: Maximum datagram size (udp only)
+                    format: int64
+            description: Application Port AppPort describes an L4 public access port/path mapping. This is used to track external to internal mappings for access via a shared load balancer or reverse proxy.
+        Appinstance:
+            type: object
+            properties:
+                app_name:
+                    type: string
+                    description: App Instance Name
+                app_vers:
+                    type: string
+                    description: App Instance Version
+                fqdn:
+                    type: string
+                    description: App Instance FQDN
+                ports:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AppPort'
+                    description: ports to access app
+                org_name:
+                    type: string
+                    description: App Organization Name
+                edge_events_cookie:
+                    type: string
+                    description: Session Cookie for specific EdgeEvents for specific AppInst
+        ClientEdgeEvent:
+            type: object
+            properties:
+                session_cookie:
+                    type: string
+                    description: Session Cookie from RegisterClientReply
+                edge_events_cookie:
+                    type: string
+                    description: Session Cookie from FindCloudletReply
+                event_type:
+                    enum:
+                        - EVENT_UNKNOWN
+                        - EVENT_INIT_CONNECTION
+                        - EVENT_TERMINATE_CONNECTION
+                        - EVENT_LATENCY_SAMPLES
+                        - EVENT_LOCATION_UPDATE
+                        - EVENT_CUSTOM_EVENT
+                    type: string
+                    format: enum
+                gps_location:
+                    $ref: '#/components/schemas/Loc'
+                samples:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Sample'
+                    description: Latency Samples if event_type is EVENT_LATENCY_SAMPLES or EVENT_CUSTOM_EVENT
+                device_info_static:
+                    $ref: '#/components/schemas/DeviceInfoStatic'
+                device_info_dynamic:
+                    $ref: '#/components/schemas/DeviceInfoDynamic'
+                custom_event:
+                    type: string
+                    description: Custom event specified by the application
+                tags:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: _(optional)_ Vendor specific data
+            description: Messages from SDK to DME
+        CloudletLocation:
+            type: object
+            properties:
+                carrier_name:
+                    type: string
+                    description: Cloudlet Organization Name
+                cloudlet_name:
+                    type: string
+                    description: Cloudlet Name
+                gps_location:
+                    $ref: '#/components/schemas/Loc'
+                distance:
+                    type: number
+                    description: Distance of cloudlet vs loc in request
+                    format: double
+                appinstances:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Appinstance'
+                    description: App instances
+        DeviceInfoDynamic:
+            type: object
+            properties:
+                data_network_type:
+                    type: string
+                    description: LTE, 5G, etc.
+                signal_strength:
+                    type: integer
+                    description: Device signal strength
+                    format: uint64
+                carrier_name:
+                    type: string
+                    description: Carrier name (can be different from cloudlet org if using "")
+            description: DeviceInfoDynamic
+        DeviceInfoStatic:
+            type: object
+            properties:
+                device_os:
+                    type: string
+                    description: Android or iOS
+                device_model:
+                    type: string
+                    description: Device model
+            description: DeviceInfoStatic
+        FindCloudletReply:
+            type: object
+            properties:
+                ver:
+                    type: integer
+                    description: API version _(hidden)_ Reserved for future use
+                    format: uint32
+                status:
+                    enum:
+                        - FIND_UNKNOWN
+                        - FIND_FOUND
+                        - FIND_NOTFOUND
+                    type: string
+                    description: Status return
+                    format: enum
+                fqdn:
+                    type: string
+                    description: Fully Qualified Domain Name of the Closest App instance
+                ports:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AppPort'
+                    description: List of Service Endpoints for AppInst
+                cloudlet_location:
+                    $ref: '#/components/schemas/Loc'
+                edge_events_cookie:
+                    type: string
+                    description: Session Cookie for specific EdgeEvents for specific AppInst
+                qos_result:
+                    enum:
+                        - QOS_NOT_ATTEMPTED
+                        - QOS_SESSION_CREATED
+                        - QOS_SESSION_FAILED
+                    type: string
+                    description: Result of QOS priority session creation attempt
+                    format: enum
+                qos_error_msg:
+                    type: string
+                    description: Error message in case of QOS_SESSION_FAILED
+                tags:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: _(optional)_ Vendor specific data
+        FindCloudletRequest:
+            type: object
+            properties:
+                ver:
+                    type: integer
+                    description: API version _(hidden)_ Reserved for future use
+                    format: uint32
+                session_cookie:
+                    type: string
+                    description: Session Cookie Session Cookie from RegisterClientRequest
+                carrier_name:
+                    type: string
+                    description: Carrier Name _(optional)_ By default, all SDKs will automatically fill in this parameter with the MCC+MNC of your current provider. Only override this parameter if you need to filter for a specific carrier on the DME. The DME will filter for App instances that are associated with the specified carrier. If you wish to search for any App Instance on the DME regardless of carrier name, you can input “” to consider all carriers as “Any”.
+                gps_location:
+                    $ref: '#/components/schemas/Loc'
+                tags:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: Tags _(optional)_ Vendor specific data
+        GoogleProtobufAny:
+            type: object
+            properties:
+                '@type':
+                    type: string
+                    description: The type of the serialized message.
+            additionalProperties: true
+            description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+        Loc:
+            type: object
+            properties:
+                latitude:
+                    type: number
+                    description: Latitude in WGS 84 coordinates
+                    format: double
+                longitude:
+                    type: number
+                    description: Longitude in WGS 84 coordinates
+                    format: double
+                horizontal_accuracy:
+                    type: number
+                    description: Horizontal accuracy (radius in meters)
+                    format: double
+                vertical_accuracy:
+                    type: number
+                    description: Vertical accuracy (meters)
+                    format: double
+                altitude:
+                    type: number
+                    description: On android only lat and long are guaranteed to be supplied Altitude in meters
+                    format: double
+                course:
+                    type: number
+                    description: Course (IOS) / bearing (Android) (degrees east relative to true north)
+                    format: double
+                speed:
+                    type: number
+                    description: Speed (IOS) / velocity (Android) (meters/sec)
+                    format: double
+                timestamp:
+                    $ref: '#/components/schemas/Timestamp'
+            description: GPS Location
+        Sample:
+            type: object
+            properties:
+                value:
+                    type: number
+                    description: Latency value
+                    format: double
+                timestamp:
+                    $ref: '#/components/schemas/Timestamp'
+                tags:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: _(optional)_ Vendor specific data
+            description: Sample
+        ServerEdgeEvent:
+            type: object
+            properties:
+                event_type:
+                    enum:
+                        - EVENT_UNKNOWN
+                        - EVENT_INIT_CONNECTION
+                        - EVENT_LATENCY_REQUEST
+                        - EVENT_LATENCY_PROCESSED
+                        - EVENT_CLOUDLET_STATE
+                        - EVENT_CLOUDLET_MAINTENANCE
+                        - EVENT_APPINST_HEALTH
+                        - EVENT_CLOUDLET_UPDATE
+                        - EVENT_ERROR
+                    type: string
+                    format: enum
+                cloudlet_state:
+                    enum:
+                        - CLOUDLET_STATE_UNKNOWN
+                        - CLOUDLET_STATE_ERRORS
+                        - CLOUDLET_STATE_READY
+                        - CLOUDLET_STATE_OFFLINE
+                        - CLOUDLET_STATE_NOT_PRESENT
+                        - CLOUDLET_STATE_INIT
+                        - CLOUDLET_STATE_UPGRADE
+                        - CLOUDLET_STATE_NEED_SYNC
+                    type: string
+                    description: Cloudlet state information if cloudlet state is not CLOUDLET_STATE_READY
+                    format: enum
+                maintenance_state:
+                    enum:
+                        - NORMAL_OPERATION
+                        - MAINTENANCE_START
+                        - FAILOVER_REQUESTED
+                        - FAILOVER_DONE
+                        - FAILOVER_ERROR
+                        - MAINTENANCE_START_NO_FAILOVER
+                        - CRM_REQUESTED
+                        - CRM_UNDER_MAINTENANCE
+                        - CRM_ERROR
+                        - NORMAL_OPERATION_INIT
+                        - UNDER_MAINTENANCE
+                    type: string
+                    description: Cloudlet maintenance state information if maintenance state is not NORMAL_OPERATION
+                    format: enum
+                health_check:
+                    enum:
+                        - HEALTH_CHECK_UNKNOWN
+                        - HEALTH_CHECK_ROOTLB_OFFLINE
+                        - HEALTH_CHECK_SERVER_FAIL
+                        - HEALTH_CHECK_OK
+                        - HEALTH_CHECK_CLOUDLET_OFFLINE
+                    type: string
+                    description: AppInst health state information if health check is not HEALTH_CHECK_OK
+                    format: enum
+                statistics:
+                    $ref: '#/components/schemas/Statistics'
+                new_cloudlet:
+                    $ref: '#/components/schemas/FindCloudletReply'
+                error_msg:
+                    type: string
+                    description: Error message if event_type is EVENT_ERROR
+                tags:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: _(optional)_ Vendor specific data
+            description: Message from DME to SDK
+        Statistics:
+            type: object
+            properties:
+                avg:
+                    type: number
+                    description: Average
+                    format: double
+                min:
+                    type: number
+                    description: Minimum
+                    format: double
+                max:
+                    type: number
+                    description: Maximum
+                    format: double
+                std_dev:
+                    type: number
+                    description: Square root of unbiased variance
+                    format: double
+                variance:
+                    type: number
+                    description: Unbiased variance
+                    format: double
+                num_samples:
+                    type: integer
+                    description: Number of samples to create stats
+                    format: uint64
+                timestamp:
+                    $ref: '#/components/schemas/Timestamp'
+            description: Statistics
+        Status:
+            type: object
+            properties:
+                code:
+                    type: integer
+                    description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+                    format: int32
+                message:
+                    type: string
+                    description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+                details:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GoogleProtobufAny'
+                    description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
+            description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'
+        Timestamp:
+            type: object
+            properties:
+                seconds:
+                    type: integer
+                    description: Time in seconds since epoch
+                    format: int64
+                nanos:
+                    type: integer
+                    description: Added non-negative sub-second time in nanoseconds
+                    format: int32
+            description: This is a simple Timestamp message type grpc-gateway converts google.protobuf.Timestamp into an RFC3339-type string which is a waste of a conversion, so we define our own
+tags:
+    - name: MatchEngineApi

--- a/dme/locverify.yaml
+++ b/dme/locverify.yaml
@@ -1,0 +1,238 @@
+# Generated with protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: Location API
+    version: v1.2.4.1-hf8
+paths:
+    /v1/getlocation:
+        post:
+            tags:
+                - Location
+            operationId: Location_GetLocation
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/GetLocationRequest'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/GetLocationReply'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/verifylocation:
+        post:
+            tags:
+                - Location
+            description: |-
+                VerifyLocation
+
+                 Verifies that the GPS coordinates accurately report the actual location of the device.
+            operationId: Location_VerifyLocation
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/VerifyLocationRequest'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/VerifyLocationReply'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+components:
+    schemas:
+        GetLocationReply:
+            type: object
+            properties:
+                ver:
+                    type: integer
+                    description: API version _(hidden)_ Reserved for future use
+                    format: uint32
+                status:
+                    enum:
+                        - LOC_UNKNOWN
+                        - LOC_FOUND
+                        - LOC_DENIED
+                    type: string
+                    format: enum
+                carrier_name:
+                    type: string
+                    description: Unique carrier identification (typically MCC + MNC)
+                tower:
+                    type: integer
+                    description: The tower that the user is currently connected to
+                    format: uint64
+                network_location:
+                    $ref: '#/components/schemas/Loc'
+                tags:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: _(optional)_ Vendor specific data
+        GetLocationRequest:
+            type: object
+            properties:
+                ver:
+                    type: integer
+                    description: API version _(hidden)_ Reserved for future use
+                    format: uint32
+                session_cookie:
+                    type: string
+                    description: Session Cookie from RegisterClientRequest
+                carrier_name:
+                    type: string
+                    description: Unique carrier identification (typically MCC + MNC)
+                tags:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: _(optional)_ Vendor specific data
+        GoogleProtobufAny:
+            type: object
+            properties:
+                '@type':
+                    type: string
+                    description: The type of the serialized message.
+            additionalProperties: true
+            description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+        Loc:
+            type: object
+            properties:
+                latitude:
+                    type: number
+                    description: Latitude in WGS 84 coordinates
+                    format: double
+                longitude:
+                    type: number
+                    description: Longitude in WGS 84 coordinates
+                    format: double
+                horizontal_accuracy:
+                    type: number
+                    description: Horizontal accuracy (radius in meters)
+                    format: double
+                vertical_accuracy:
+                    type: number
+                    description: Vertical accuracy (meters)
+                    format: double
+                altitude:
+                    type: number
+                    description: On android only lat and long are guaranteed to be supplied Altitude in meters
+                    format: double
+                course:
+                    type: number
+                    description: Course (IOS) / bearing (Android) (degrees east relative to true north)
+                    format: double
+                speed:
+                    type: number
+                    description: Speed (IOS) / velocity (Android) (meters/sec)
+                    format: double
+                timestamp:
+                    $ref: '#/components/schemas/Timestamp'
+            description: GPS Location
+        Status:
+            type: object
+            properties:
+                code:
+                    type: integer
+                    description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+                    format: int32
+                message:
+                    type: string
+                    description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+                details:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GoogleProtobufAny'
+                    description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
+            description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'
+        Timestamp:
+            type: object
+            properties:
+                seconds:
+                    type: integer
+                    description: Time in seconds since epoch
+                    format: int64
+                nanos:
+                    type: integer
+                    description: Added non-negative sub-second time in nanoseconds
+                    format: int32
+            description: This is a simple Timestamp message type grpc-gateway converts google.protobuf.Timestamp into an RFC3339-type string which is a waste of a conversion, so we define our own
+        VerifyLocationReply:
+            type: object
+            properties:
+                ver:
+                    type: integer
+                    description: API version _(hidden)_ Reserved for future use
+                    format: uint32
+                tower_status:
+                    enum:
+                        - TOWER_UNKNOWN
+                        - CONNECTED_TO_SPECIFIED_TOWER
+                        - NOT_CONNECTED_TO_SPECIFIED_TOWER
+                    type: string
+                    format: enum
+                gps_location_status:
+                    enum:
+                        - LOC_UNKNOWN
+                        - LOC_VERIFIED
+                        - LOC_MISMATCH_SAME_COUNTRY
+                        - LOC_MISMATCH_OTHER_COUNTRY
+                        - LOC_ROAMING_COUNTRY_MATCH
+                        - LOC_ROAMING_COUNTRY_MISMATCH
+                        - LOC_ERROR_UNAUTHORIZED
+                        - LOC_ERROR_OTHER
+                    type: string
+                    format: enum
+                gps_location_accuracy_km:
+                    type: number
+                    description: location accuracy, the location is verified to be within this number of kilometers.  Negative value means no verification was performed
+                    format: double
+                tags:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: _(optional)_ Vendor specific data
+        VerifyLocationRequest:
+            type: object
+            properties:
+                ver:
+                    type: integer
+                    description: API version _(hidden)_ Reserved for future use
+                    format: uint32
+                session_cookie:
+                    type: string
+                    description: Session Cookie Session Cookie from RegisterClientRequest
+                carrier_name:
+                    type: string
+                    description: Carrier Name Unique carrier identification (typically MCC + MNC)
+                gps_location:
+                    $ref: '#/components/schemas/Loc'
+                verify_loc_token:
+                    type: string
+                    description: Verify Location Token Must be retrieved from TokenServerURI
+                tags:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: Tags _(optional)_ Vendor specific data
+tags:
+    - name: Location

--- a/dme/qos-position.yaml
+++ b/dme/qos-position.yaml
@@ -1,0 +1,225 @@
+# Generated with protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: QosPositionKpi API
+    version: v1.2.4.1-hf8
+paths:
+    /v1/getqospositionkpi:
+        post:
+            tags:
+                - QosPositionKpi
+            operationId: QosPositionKpi_GetQosPositionKpi
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/QosPositionRequest'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/QosPositionKpiReply'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+components:
+    schemas:
+        BandSelection:
+            type: object
+            properties:
+                rat2g:
+                    type: array
+                    items:
+                        type: string
+                    description: Radio Access Technologies
+                rat3g:
+                    type: array
+                    items:
+                        type: string
+                rat4g:
+                    type: array
+                    items:
+                        type: string
+                rat5g:
+                    type: array
+                    items:
+                        type: string
+            description: supported band values
+        GoogleProtobufAny:
+            type: object
+            properties:
+                '@type':
+                    type: string
+                    description: The type of the serialized message.
+            additionalProperties: true
+            description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+        Loc:
+            type: object
+            properties:
+                latitude:
+                    type: number
+                    description: Latitude in WGS 84 coordinates
+                    format: double
+                longitude:
+                    type: number
+                    description: Longitude in WGS 84 coordinates
+                    format: double
+                horizontal_accuracy:
+                    type: number
+                    description: Horizontal accuracy (radius in meters)
+                    format: double
+                vertical_accuracy:
+                    type: number
+                    description: Vertical accuracy (meters)
+                    format: double
+                altitude:
+                    type: number
+                    description: On android only lat and long are guaranteed to be supplied Altitude in meters
+                    format: double
+                course:
+                    type: number
+                    description: Course (IOS) / bearing (Android) (degrees east relative to true north)
+                    format: double
+                speed:
+                    type: number
+                    description: Speed (IOS) / velocity (Android) (meters/sec)
+                    format: double
+                timestamp:
+                    $ref: '#/components/schemas/Timestamp'
+            description: GPS Location
+        QosPosition:
+            type: object
+            properties:
+                positionid:
+                    type: integer
+                    description: as set by the client, must be unique within QosRequest
+                    format: int64
+                gps_location:
+                    $ref: '#/components/schemas/Loc'
+        QosPositionKpiReply:
+            type: object
+            properties:
+                ver:
+                    type: integer
+                    description: API version _(hidden)_ Reserved for future use
+                    format: uint32
+                status:
+                    enum:
+                        - RS_UNDEFINED
+                        - RS_SUCCESS
+                        - RS_FAIL
+                    type: string
+                    description: Status of the reply
+                    format: enum
+                position_results:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/QosPositionKpiResult'
+                    description: kpi details
+                tags:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: _(optional)_ Vendor specific data
+        QosPositionKpiResult:
+            type: object
+            properties:
+                positionid:
+                    type: integer
+                    description: as set by the client, must be unique within one QosPositionRequest
+                    format: int64
+                gps_location:
+                    $ref: '#/components/schemas/Loc'
+                dluserthroughput_min:
+                    type: number
+                    description: throughput
+                    format: float
+                dluserthroughput_avg:
+                    type: number
+                    format: float
+                dluserthroughput_max:
+                    type: number
+                    format: float
+                uluserthroughput_min:
+                    type: number
+                    format: float
+                uluserthroughput_avg:
+                    type: number
+                    format: float
+                uluserthroughput_max:
+                    type: number
+                    format: float
+                latency_min:
+                    type: number
+                    format: float
+                latency_avg:
+                    type: number
+                    format: float
+                latency_max:
+                    type: number
+                    format: float
+        QosPositionRequest:
+            type: object
+            properties:
+                ver:
+                    type: integer
+                    description: API version _(hidden)_ Reserved for future use
+                    format: uint32
+                session_cookie:
+                    type: string
+                    description: Session Cookie from RegisterClientRequest
+                positions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/QosPosition'
+                    description: list of positions
+                lte_category:
+                    type: integer
+                    description: _(optional)_ Client's device LTE category number.
+                    format: int32
+                band_selection:
+                    $ref: '#/components/schemas/BandSelection'
+                tags:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: _(optional)_ Vendor specific data
+            description: QosPositionRequest is used for both GetQosPositionKpi
+        Status:
+            type: object
+            properties:
+                code:
+                    type: integer
+                    description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+                    format: int32
+                message:
+                    type: string
+                    description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+                details:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GoogleProtobufAny'
+                    description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
+            description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'
+        Timestamp:
+            type: object
+            properties:
+                seconds:
+                    type: integer
+                    description: Time in seconds since epoch
+                    format: int64
+                nanos:
+                    type: integer
+                    description: Added non-negative sub-second time in nanoseconds
+                    format: int32
+            description: This is a simple Timestamp message type grpc-gateway converts google.protobuf.Timestamp into an RFC3339-type string which is a waste of a conversion, so we define our own
+tags:
+    - name: QosPositionKpi

--- a/dme/qos.yaml
+++ b/dme/qos.yaml
@@ -1,0 +1,242 @@
+# Generated with protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: QualityOfService API
+    version: v1.2.4.1-hf8
+paths:
+    /v1/qosprioritysessioncreate:
+        post:
+            tags:
+                - QualityOfService
+            description: |-
+                QosPrioritySessionCreate
+
+                 Creates a QOS priority session (latency or throughput priority) from the client
+                 to the app inst by making a call to the operator's priority session API server.
+            operationId: QualityOfService_QosPrioritySessionCreate
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/QosPrioritySessionCreateRequest'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/QosPrioritySessionReply'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/qosprioritysessiondelete:
+        post:
+            tags:
+                - QualityOfService
+            description: "QosPrioritySessionDelete\n\n Deletes a previously created QOS priority session by making a call to the operator's \n priority session API server."
+            operationId: QualityOfService_QosPrioritySessionDelete
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/QosPrioritySessionDeleteRequest'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/QosPrioritySessionDeleteReply'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+components:
+    schemas:
+        GoogleProtobufAny:
+            type: object
+            properties:
+                '@type':
+                    type: string
+                    description: The type of the serialized message.
+            additionalProperties: true
+            description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+        QosPrioritySessionCreateRequest:
+            type: object
+            properties:
+                ver:
+                    type: integer
+                    description: API version _(hidden)_ Reserved for future use
+                    format: uint32
+                session_cookie:
+                    type: string
+                    description: Session Cookie from RegisterClientRequest
+                session_duration:
+                    type: integer
+                    description: _(optional)_ QOS Priority Session duration in seconds
+                    format: uint32
+                ip_user_equipment:
+                    type: string
+                    description: IP address of mobile device
+                ip_application_server:
+                    type: string
+                    description: IP address of the application server
+                port_user_equipment:
+                    type: string
+                    description: _(optional)_ A list of single ports or port ranges on the user equipment.
+                port_application_server:
+                    type: string
+                    description: _(optional)_ A list of single ports or port ranges on the application server
+                protocol_in:
+                    enum:
+                        - TCP
+                        - UDP
+                        - ANY
+                    type: string
+                    description: _(optional)_ The used transport protocol for the uplink
+                    format: enum
+                protocol_out:
+                    enum:
+                        - TCP
+                        - UDP
+                        - ANY
+                    type: string
+                    description: _(optional)_ The used transport protocol for the downlink
+                    format: enum
+                profile:
+                    enum:
+                        - QOS_NO_PRIORITY
+                        - QOS_LOW_LATENCY
+                        - QOS_THROUGHPUT_DOWN_S
+                        - QOS_THROUGHPUT_DOWN_M
+                        - QOS_THROUGHPUT_DOWN_L
+                    type: string
+                    description: QOS Priority Session profile name
+                    format: enum
+                notification_uri:
+                    type: string
+                    description: _(optional)_ URI of the callback receiver. Allows asynchronous delivery of session related events.
+                notification_auth_token:
+                    type: string
+                    description: _(optional)_ Authentification token for callback API
+                tags:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: _(optional)_ Vendor specific data
+        QosPrioritySessionDeleteReply:
+            type: object
+            properties:
+                ver:
+                    type: integer
+                    description: API version _(hidden)_ Reserved for future use
+                    format: uint32
+                status:
+                    enum:
+                        - QDEL_UNKNOWN
+                        - QDEL_DELETED
+                        - QDEL_NOT_FOUND
+                    type: string
+                    description: Status return.
+                    format: enum
+                tags:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: _(optional)_ Vendor specific data
+        QosPrioritySessionDeleteRequest:
+            type: object
+            properties:
+                ver:
+                    type: integer
+                    description: API version _(hidden)_ Reserved for future use
+                    format: uint32
+                session_cookie:
+                    type: string
+                    description: Session Cookie from RegisterClientRequest
+                profile:
+                    enum:
+                        - QOS_NO_PRIORITY
+                        - QOS_LOW_LATENCY
+                        - QOS_THROUGHPUT_DOWN_S
+                        - QOS_THROUGHPUT_DOWN_M
+                        - QOS_THROUGHPUT_DOWN_L
+                    type: string
+                    description: QOS Priority Session profile name
+                    format: enum
+                session_id:
+                    type: string
+                    description: QOS Priority Session ID to be deleted
+                tags:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: _(optional)_ Vendor specific data
+        QosPrioritySessionReply:
+            type: object
+            properties:
+                ver:
+                    type: integer
+                    description: API version _(hidden)_ Reserved for future use
+                    format: uint32
+                session_duration:
+                    type: integer
+                    description: QOS Priority Session duration in seconds
+                    format: uint32
+                profile:
+                    enum:
+                        - QOS_NO_PRIORITY
+                        - QOS_LOW_LATENCY
+                        - QOS_THROUGHPUT_DOWN_S
+                        - QOS_THROUGHPUT_DOWN_M
+                        - QOS_THROUGHPUT_DOWN_L
+                    type: string
+                    description: QOS Priority Session profile name
+                    format: enum
+                session_id:
+                    type: string
+                    description: Session ID in UUID format
+                started_at:
+                    type: integer
+                    description: Timestamp of session start in seconds since unix epoch
+                    format: uint32
+                expires_at:
+                    type: integer
+                    description: Timestamp of session expiration if the session was not deleted in seconds since unix epoch
+                    format: uint32
+                http_status:
+                    type: integer
+                    description: HTTP Status Code of call to operator's API server.
+                    format: uint32
+                tags:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: _(optional)_ Vendor specific data
+        Status:
+            type: object
+            properties:
+                code:
+                    type: integer
+                    description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+                    format: int32
+                message:
+                    type: string
+                    description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+                details:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GoogleProtobufAny'
+                    description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
+            description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'
+tags:
+    - name: QualityOfService

--- a/dme/session.yaml
+++ b/dme/session.yaml
@@ -1,0 +1,131 @@
+# Generated with protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: Session API
+    version: v1.2.4.1-hf8
+paths:
+    /v1/registerclient:
+        post:
+            tags:
+                - Session
+            description: |-
+                RegisterClient
+
+                 Registers the client with the closest Distributed Matching Engine (the
+                 nearest edge location in the Operator network) and validates the
+                 legitimacy of the mobile subscriber. All session information is encrypted.
+            operationId: Session_RegisterClient
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/RegisterClientRequest'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/RegisterClientReply'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+components:
+    schemas:
+        GoogleProtobufAny:
+            type: object
+            properties:
+                '@type':
+                    type: string
+                    description: The type of the serialized message.
+            additionalProperties: true
+            description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+        RegisterClientReply:
+            type: object
+            properties:
+                ver:
+                    type: integer
+                    description: API version _(hidden)_ Reserved for future use
+                    format: uint32
+                status:
+                    enum:
+                        - RS_UNDEFINED
+                        - RS_SUCCESS
+                        - RS_FAIL
+                    type: string
+                    description: Status of the reply
+                    format: enum
+                session_cookie:
+                    type: string
+                    description: Session Cookie to be used in later API calls
+                token_server_uri:
+                    type: string
+                    description: URI for the Token Server
+                unique_id_type:
+                    type: string
+                    description: Unique ID Type _(optional)_ Type of unique ID provided by the server A unique_id_type and unique_id may be provided by the client to be registered. During registering, if a unique_id_type and unique_id are provided by the client in their request, the unique_id_type and unique_id will be left blank in the response. But, if the client does not provide a unique_id_type and unique_id, then the server generates one and provides the unique_id in the response. If possible, the unique_id should be saved by the client locally and used for subsequent RegisterClient API calls. Otherwise, a new unique_id will be generated for further API calls.
+                unique_id:
+                    type: string
+                    description: Unique ID _(optional)_ Unique identification of the client device or user A unique_id_type and unique_id may be provided by the client to be registered. During registering, if a unique_id_type and unique_id are provided by the client in their request, the unique_id_type and unique_id will be left blank in the response. But, if the client does not provide a unique_id_type and unique_id, then the server generates one and provides the unique_id in the response. If possible, the unique_id should be saved by the client locally and used for subsequent RegisterClient API calls. Otherwise, a new unique_id will be generated for further API calls.
+                tags:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: Vendor specific data _(optional)_ Array of Tags.
+        RegisterClientRequest:
+            type: object
+            properties:
+                ver:
+                    type: integer
+                    description: API version _(hidden)_ Reserved for future use
+                    format: uint32
+                org_name:
+                    type: string
+                    description: App Organization Name App developer organization name.
+                app_name:
+                    type: string
+                    description: App Name Name of your application.
+                app_vers:
+                    type: string
+                    description: App Version Application version.
+                carrier_name:
+                    type: string
+                    description: Carrier Name _(hidden)_ Reserved for future use
+                auth_token:
+                    type: string
+                    description: Authentication Token _(optional)_ An authentication token supplied by the application.
+                unique_id_type:
+                    type: string
+                    description: Unique ID Type _(optional)_ Type of unique ID provided by the client. If left blank, a new Unique ID type will be assigned in the RegisterClient Reply.
+                unique_id:
+                    type: string
+                    description: Unique ID _(optional)_ Unique identification of the client device or user. May be overridden by the server. If left blank, a new Unique ID will be assigned in the RegisterClient Reply.
+                tags:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: Tags _(optional)_ Vendor specific data
+        Status:
+            type: object
+            properties:
+                code:
+                    type: integer
+                    description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+                    format: int32
+                message:
+                    type: string
+                    description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+                details:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GoogleProtobufAny'
+                    description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
+            description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'
+tags:
+    - name: Session


### PR DESCRIPTION
These are the generated openapi docs for each separate set of APIs corresponding roughly to different CAMARA working groups. These can be used as a starting point or reference point for developing the CAMARA APIs.