### PR TITLE
add http proto

### DIFF
--- a/dme/appcommon.proto
+++ b/dme/appcommon.proto
@@ -27,6 +27,7 @@ import "edgeprotogen.proto";
 // 0: `L_PROTO_UNKNOWN`
 // 1: `L_PROTO_TCP`
 // 2: `L_PROTO_UDP`
+// 3: `L_PROTO_HTTP`
 enum LProto {
   // Unknown protocol
   L_PROTO_UNKNOWN = 0;
@@ -34,6 +35,8 @@ enum LProto {
   L_PROTO_TCP = 1;
   // UDP (L4) protocol
   L_PROTO_UDP = 2;
+  // HTTP (L7) protocol
+  L_PROTO_HTTP = 3;
 }
 
 // Application Port


### PR DESCRIPTION
Add HTTP as a protocol option, to allow for traffic to be steered through an HTTP ingress in Kubernetes.